### PR TITLE
Install kmod and xz in a docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:30
-RUN dnf install -y python3 bcc && dnf clean all
+RUN dnf install -y python3 bcc kmod xz && dnf clean all
 ADD ./ /ipftrace/
 ENV PYTHONUNBUFFERED=1
 RUN cd /ipftrace && pip3 install -e .


### PR DESCRIPTION
bcc runs `modprobe kheaders` to extract kernel headers when
/lib/modules/`uname -r`/sources is not available and tries to decompress
/sys/kernel/kheaders.tar.xz. `modprobe` requires kmod and `tar xz` does
xz package. Install these packages.

Signed-off-by: Masanori Misono <m.misono760@gmail.com>