### PR TITLE
Exclude non available functions from tracing

### DIFF
--- a/ipftrace/ipftrace.py
+++ b/ipftrace/ipftrace.py
@@ -100,8 +100,10 @@ class DefaultModule:
 
 class IPFTracer:
     def __init__(
-        self, iv, saddr, daddr, proto, sport, dport, module, regex, length, manifest
+        self, iv, saddr, daddr, proto, sport, dport, module, regex, length,
+        manifest, verbose,
     ):
+        self._verbose = verbose
         self._opts = self._build_opts(iv, saddr, daddr, proto, sport, dport)
         self._functions = self._read_functions(manifest)
         self._module = self._load_module(module)
@@ -118,7 +120,8 @@ class IPFTracer:
             if f["name"] in available_funcs:
                 filtered_funcs.append(f)
             else:
-                print(f'Function {f["name"]} is not traceable. Skip.')
+                if self._verbose:
+                    print(f'Function {f["name"]} is not traceable. Skip.')
         return filtered_funcs
 
     def _read_manifest(self, manifest):
@@ -342,6 +345,7 @@ class IPFTracer:
 @click.option("-r", "--regex", default=None, help="Filter the function names by regex")
 @click.option("-l", "--length", default=80, help="Specify the length of function trace")
 @click.option("-ls", "--list-func", is_flag=True, help="List available functions")
+@click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.argument("manifest")
 def main(
     ipversion,
@@ -354,6 +358,7 @@ def main(
     regex,
     length,
     list_func,
+    verbose,
     manifest,
 ):
     """
@@ -373,6 +378,7 @@ def main(
         regex=regex,
         length=length,
         manifest=manifest,
+        verbose=verbose,
     )
 
     if list_func:


### PR DESCRIPTION
When I ran ipftrace (on Linux 5.5, which I built), I saw the following
warnings.

```
% sudo ipftrace -p ICMP linux5.5.yaml
Loading module "Default"
cannot attach kprobe, Invalid argument
Couldn't attach kprobe to function nla_append
cannot attach kprobe, Invalid argument
Couldn't attach kprobe to function nla_put_nohdr
Couldn't attach kprobe to function nla_put_64bit
cannot attach kprobe, Invalid argument
[...]
```

After some investigation, I found that `nla_append` (and other
some funcations) was not listed in
/sys/kernel/debug/tracing/available_filter_functions, which mean that
the function was not traceable (with ftrace). I really not sure why the
function is not traceable. The function is not marked with notrace nor
inlined.

Anyway, kernel BTF includes information on functions marked with
notrace. In addition, it is possible for a manifest file to contain
function names not available in a tracee kernel. Exclude these non
traceable functions by consulting
/sys/kernel/debug/tracing/available_filter_functions.